### PR TITLE
fix jitpack ref and add jbang-catalog

### DIFF
--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -1,0 +1,10 @@
+{
+  "catalogs": {},
+  "aliases": {
+    "jfxcentral": {
+      "script-ref": "main.java",
+      "properties": {}
+    }
+  },
+  "templates": {}
+}

--- a/main.java
+++ b/main.java
@@ -14,7 +14,7 @@
 //DEPS org.openjfx:javafx-fxml:18-ea+9:${os.detected.jfxname}
 
 // actual jar we want to run
-//DEPS com.github.maxandersen:jfxcentral:jbang-SNAPSHOT
+//DEPS com.github.dlemmermann:jfxcentral:-SNAPSHOT
 
 import com.dlsc.jfxcentral.JFXCentralApp;
 

--- a/main.java
+++ b/main.java
@@ -1,4 +1,5 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
+//JAVA 11+
 //REPOS jitpack,mavencentral
 //REPOS sandec=https://sandec.jfrog.io/artifactory/repo
 // gluon does not seem necessary


### PR DESCRIPTION
fix to use dlemmermann snapshot rather than maxandersen.

add example jbang-catalog.json which let you run using `jbang jfxcentral@dlemmermann/jfxcentral`
+ makes it eventually show up on jbang.dev/appstore.

I would suggest to create a dlemmermann/jbang-catalog repo since then you can shorten the run to be `jbang jfxcentral@dlemmermann`


